### PR TITLE
Add elmi-to-json dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const _ = require("lodash"),
 
 const binaryExtension = process.platform === "win32" ? ".exe" : "";
 const readElmiPath =
-  path.join(__dirname, "bin", "elmi-to-json") + binaryExtension;
+  path.join(__dirname, "node_modules", ".bin", "elmi-to-json") + binaryExtension;
 const jsEmitterFilename = "emitter.js";
 
 module.exports = function(

--- a/js/find-exposed-values.js
+++ b/js/find-exposed-values.js
@@ -18,7 +18,7 @@ function findExposedValues(
 ) {
   return new Promise(function(resolve, reject) {
     function finish() {
-      var process = spawn("elmi-to-json", [], {cwd: elmPackageJsonPath });
+      var process = spawn(path.join(__dirname, "..", "node_modules", ".bin", "elmi-to-json"), [], {cwd: elmPackageJsonPath});
       var jsonStr = "";
       var stderrStr = "";
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chalk": "2.1.0",
     "commander": "2.9.0",
     "cross-spawn": "5.1.0",
+    "elmi-to-json": "^0.19.4",
     "firstline": "1.2.1",
     "fs-extra": "4.0.1",
     "glob": "7.1.2",


### PR DESCRIPTION
Hi,

The CLI assumes that `elmi-to-json` is installed and in your `$PATH`. Instead of creating an issue, I thought I'd submit a PR with a quick and dirty way to fix this, by adding the `elmi-to-json` as a dependency, and using its executable instead of an assumed already available one.

I'm sure there are many nicer ways of doing this (I can think of at least one!), but as it's an unfamiliar codebase I have no ownership over, I just added the bare minimum needed to fix the issue. So feel free to ignore the PR! But maybe at least add a note in the `README` that it requires you have `elmi-to-json` globally installed before use.