### PR TITLE
Rename --pathToMake to --pathToElm

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const jsEmitterFilename = "emitter.js";
 module.exports = function(
   projectDir /*: string*/,
   outputDir /*: string */,
-  pathToMake /*: ?string */
+  pathToElm /*: ?string */
 ) {
   const cssSourceDir = path.join(projectDir, "css");
   const cssElmPackageJson = path.join(cssSourceDir, "elm.json");
@@ -76,7 +76,7 @@ module.exports = function(
   return Promise.all([
     writeGeneratedElmPackage(generatedDir, generatedSrc, cssSourceDir),
     makeGeneratedSrcDir,
-    compileAll(pathToMake, cssSourceDir, elmFilePaths)
+    compileAll(pathToElm, cssSourceDir, elmFilePaths)
   ]).then(function(promiseOutputs) {
     const repository /*: string */ = promiseOutputs[0];
 
@@ -107,7 +107,7 @@ module.exports = function(
           repository,
           path.join(generatedDir, jsEmitterFilename),
           generatedDir,
-          pathToMake
+          pathToElm
         ).then(writeResults(outputDir));
       });
     });
@@ -119,13 +119,13 @@ function emit(
   repository /*: string */,
   dest /*: string */,
   cwd /*: string */,
-  pathToMake /*: ?string */
+  pathToElm /*: ?string */
 ) {
   // Compile the js file.
   return compileEmitter(src, {
     output: dest,
     cwd: cwd,
-    pathToMake: pathToMake
+    pathToElm: pathToElm
   })
     //.then(function() {
     //  return hackMain(repository, dest);

--- a/js/cli.js
+++ b/js/cli.js
@@ -17,7 +17,7 @@ program
     "(optional) directory in which to write CSS files. Defaults to build/",
     path.join(process.cwd(), "build")
   )
-  .option("-m, --pathToMake [pathToMake]", "(optional) path to elm-make")
+  .option("-m, --pathToElm [pathToElm]", "(optional) path to elm")
   .parse(process.argv);
 
 const cssSourceDir = path.join(process.cwd(), "css");
@@ -34,7 +34,7 @@ const bar = _.repeat("-", headline.length);
 
 console.log("\n" + headline + "\n" + bar + "\n");
 
-elmCss(process.cwd(), program.output, program.pathToMake)
+elmCss(process.cwd(), program.output, program.pathToElm)
   .then(function(results) {
     console.log(chalk.green("Success! I created these css files:"));
     results.forEach(function(result) {

--- a/js/compile-all.js
+++ b/js/compile-all.js
@@ -11,7 +11,7 @@ const compile = require("node-elm-compiler").compile,
 // This compiles all the tests so that we generate *.elmi files for them,
 // which we can then read to determine which tests need to be run.
 module.exports = function compileAll(
-  pathToMake /*: ?string */,
+  pathToElm /*: ?string */,
   cwd /*: string */,
   testFilePaths /*: Array<string> */
 ) {
@@ -20,7 +20,7 @@ module.exports = function compileAll(
       output: "/dev/null",
       verbose: false,
       cwd: cwd,
-      pathToMake: pathToMake,
+      pathToElm: pathToElm,
       processOpts: { stdio: ["ignore", "ignore", "inherit"] }
     });
 


### PR DESCRIPTION
Hi,

`node-elm-compiler` changed from using the `--pathToMake` flag to using the `--pathToElm` flag when v.19 was released, but `css-in-elm` (and its help docs) are still trying to use the old flag, so it errors when you try to use either.

This PR is basically a find and replace of pathToMake → pathToElm. I've tested it with my project, although a relative path doesn't seem to work, at least when calling `js/cli.js` directly, e.g. calling `../css-in-elm/js/cli.js --pathToElm node_modules/.bin/elm` from my project directory doesn't work, but `../css-in-elm/js/cli.js --pathToElm $PWD/node_modules/.bin/elm` does. I suspect it might work when calling the linked `css-in-elm` executable, though?